### PR TITLE
the additional comma prevents the image from executing without an err…

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.13.4",
-    "express-handlebars": "^3.0.0",
-    
+    "express-handlebars": "^3.0.0"    
   },
   "devDependencies": {
     "gulp": "^3.9.1",


### PR DESCRIPTION
…or - and running the gulp-watch

Error was:
mac-terminal$ docker-compose up
Creating dockergulp_web_1 ... 
Creating dockergulp_web_1 ... done
Attaching to dockergulp_web_1
web_1  | [11:47:18] Local gulp not found in /app
web_1  | [11:47:18] Try running: npm install gulp
dockergulp_web_1 exited with code 1

Fixed with changes Now:
...
Creating dockergulp_web_1 ... 
Creating dockergulp_web_1 ... done
Attaching to dockergulp_web_1
web_1  | [11:48:45] Using gulpfile /app/gulpfile.js
web_1  | [11:48:45] Starting 'server'...
web_1  | [11:48:45] Finished 'server' after 2.84 ms
web_1  | [11:48:45] Starting 'serve:devserver'...
web_1  | [11:48:45] Finished 'serve:devserver' after 13 ms
web_1  | [11:48:45] Starting 'default'...
web_1  | [11:48:45] Finished 'default' after 95 μs
web_1  | Example app listening at http://:::4000